### PR TITLE
Return job on add

### DIFF
--- a/lib/que.ex
+++ b/lib/que.ex
@@ -110,7 +110,7 @@ defmodule Que do
   #=> :ok
   ```
   """
-  @spec add(worker :: module, arguments :: term) :: :ok
+  @spec add(worker :: module, arguments :: term) :: {:ok, %Que.Job{}}
   defdelegate add(worker, arguments), to: Que.ServerSupervisor
 
 end

--- a/lib/que/server.ex
+++ b/lib/que/server.ex
@@ -90,7 +90,7 @@ defmodule Que.Server do
       |> Que.Queue.put(job)
       |> Que.Queue.process
 
-    {:reply, :ok, queue}
+    {:reply, {:ok, job}, queue}
   end
 
 

--- a/test/que/server_test.exs
+++ b/test/que/server_test.exs
@@ -63,4 +63,19 @@ defmodule Que.Test.Server do
     Que.Server.stop(TestWorker)
   end
 
+  @tag capture_log: true
+  test "#add returns the enqueued job" do
+    Que.Server.start_link(TestWorker)
+
+    {:ok, job} = Que.Server.add(TestWorker, "my_arg")
+
+    assert match?(%Que.Job{
+      arguments: "my_arg",
+      id: 1,
+      status: :queued,
+      worker: TestWorker,
+    }, job)
+
+    Que.Server.stop(TestWorker)
+  end
 end


### PR DESCRIPTION
Currently there's no way to get a reference to an added job. This is fine for "fire-and-forget" jobs, but it's a problem if you need to check the progress of a specific job.

This change is backwards incompatible, as you can see in the typespec change. If that's an issue, a new function (ex: `add_and_get`) could be added with the new behaviour.