### PR TITLE
Add setup and teardown callbacks

### DIFF
--- a/lib/que/job.ex
+++ b/lib/que/job.ex
@@ -59,6 +59,7 @@ defmodule Que.Job do
 
     {:ok, pid} =
       Que.Helpers.do_task(fn ->
+        job.worker.on_setup(job)
         job.worker.perform(job.arguments)
       end)
 
@@ -78,6 +79,7 @@ defmodule Que.Job do
 
     Que.Helpers.do_task(fn ->
       job.worker.on_success(job.arguments)
+      job.worker.on_teardown(job)
     end)
 
     %{ job | status: :completed, pid: nil, ref: nil }
@@ -96,6 +98,7 @@ defmodule Que.Job do
 
     Que.Helpers.do_task(fn ->
       job.worker.on_failure(job.arguments, error)
+      job.worker.on_teardown(job)
     end)
 
     %{ job | status: :failed, pid: nil, ref: nil }

--- a/lib/que/worker.ex
+++ b/lib/que/worker.ex
@@ -174,7 +174,15 @@ defmodule Que.Worker do
       end
 
 
-      defoverridable [on_success: 1, on_failure: 2]
+      def on_setup(_job) do
+      end
+
+
+      def on_teardown(_job) do
+      end
+
+
+      defoverridable [on_success: 1, on_failure: 2, on_setup: 1, on_teardown: 1]
 
 
 
@@ -232,4 +240,20 @@ defmodule Que.Worker do
   """
   @callback on_failure(arguments :: term, error :: tuple) :: term
 
+
+
+
+  @doc """
+  Optional callback that is executed before the job is started.
+  """
+  @callback on_setup(job :: term) :: term
+
+
+
+
+  @doc """
+  Optional callback that is executed after the job finishes,
+  both on success and failure.
+  """
+  @callback on_teardown(job :: term) :: term
 end


### PR DESCRIPTION
This feature introduces two new worker callbacks, `on_setup` and `on_teardown`, that expose the whole job struct, not just its arguments. My intended use case was to add a custom per-job logger backend, but it can be used to run any setup / cleanup code that depends on a job's id, pid, etc.

This PR also fixes a timing dependent test intermittence which happened when a spawned job task took longer than 3ms to finish. This is accomplished by introducing a `wait_for_children` helper which monitors the spawned tasks.