### PR TITLE
Make concurrency/0 overridable by workers

### DIFF
--- a/lib/que/worker.ex
+++ b/lib/que/worker.ex
@@ -182,7 +182,7 @@ defmodule Que.Worker do
       end
 
 
-      defoverridable [on_success: 1, on_failure: 2, on_setup: 1, on_teardown: 1]
+      defoverridable [on_success: 1, on_failure: 2, on_setup: 1, on_teardown: 1, concurrency: 0]
 
 
 


### PR DESCRIPTION
The only change introduced in this PR is commit `96e47b0` which allows a worker to override `concurrency/0` which makes workers capable of specifying their concurrency dynamically at run-time. This change conflicts with #14 if introduced separately, that's why this branch was based on that PR's branch. This PR can be rebased after #14 is merged.