### PR TITLE
Fetch results from jobs

### DIFF
--- a/lib/que/helpers.ex
+++ b/lib/que/helpers.ex
@@ -32,9 +32,9 @@ defmodule Que.Helpers do
   @doc """
   Off-loads tasks to custom `Que.TaskSupervisor`
   """
-  @spec do_task((() -> any)) :: {:ok, pid}
+  @spec do_task((() -> any)) :: Task.t()
   def do_task(fun) do
-    Task.Supervisor.start_child(Que.TaskSupervisor, fun)
+    Task.Supervisor.async_nolink(Que.TaskSupervisor, fun)
   end
 
 

--- a/lib/que/queue.ex
+++ b/lib/que/queue.ex
@@ -105,8 +105,10 @@ defmodule Que.Queue do
   @spec find(queue :: Que.Queue.t, key :: atom, value :: term) :: Que.Job.t | nil
   def find(queue, key \\ :id, value)
 
+  # job.ref is actually a Task. So, we need to access job.ref.ref to get
+  # the real reference of a job.
   def find(%Que.Queue{ running: running }, :ref, value) do
-    Enum.find(running, &(Map.get(&1, :ref) == value))
+    Enum.find(running, &(Map.get(&1, :ref) |> Map.get(:ref) == value))
   end
 
   def find(%Que.Queue{} = q, key, value) do

--- a/test/que/job_test.exs
+++ b/test/que/job_test.exs
@@ -71,7 +71,10 @@ defmodule Que.Test.Job do
         SetupAndTeardownWorker
         |> Job.new
         |> Job.perform
-        |> Job.handle_success
+
+      result = Task.await(job.ref)
+
+      job = job |> Job.handle_success(result)
 
       assert job.status == :completed
       assert job.pid    == nil
@@ -109,10 +112,12 @@ defmodule Que.Test.Job do
 
   test "#handle_success works as expected" do
     capture = Helpers.capture_log(fn ->
+      result = true
+
       job =
         SuccessWorker
         |> Job.new
-        |> Job.handle_success
+        |> Job.handle_success(result)
 
       assert job.status == :completed
       assert job.pid    == nil
@@ -122,7 +127,7 @@ defmodule Que.Test.Job do
     end)
 
     assert capture =~ ~r/Completed/
-    assert capture =~ ~r/success: nil/
+    assert capture =~ ~r/success/
   end
 
 
@@ -141,7 +146,7 @@ defmodule Que.Test.Job do
     end)
 
     assert capture =~ ~r/Failed/
-    assert capture =~ ~r/failure: nil/
+    assert capture =~ ~r/failure/
   end
 
 end

--- a/test/support.ex
+++ b/test/support.ex
@@ -27,7 +27,7 @@ defmodule Que.Test.Meta do
     use Que.Worker
 
     def perform(args),    do: Logger.debug("#{__MODULE__} - perform: #{inspect(args)}")
-    def on_success(args), do: Logger.debug("#{__MODULE__} - success: #{inspect(args)}")
+    def on_success(job, _result), do: Logger.debug("#{__MODULE__} - success: #{inspect(job)}")
   end
 
 
@@ -39,7 +39,7 @@ defmodule Que.Test.Meta do
       raise "some error"
     end
 
-    def on_failure(args, _err), do: Logger.debug("#{__MODULE__} - failure: #{inspect(args)}")
+    def on_failure(job, _err), do: Logger.debug("#{__MODULE__} - failure: #{inspect(job)}")
   end
 
 
@@ -51,8 +51,8 @@ defmodule Que.Test.Meta do
       Logger.debug("#{__MODULE__} - perform: #{inspect(args)}")
     end
 
-    def on_success(args),       do: Logger.debug("#{__MODULE__} - success: #{inspect(args)}")
-    def on_failure(args, _err), do: Logger.debug("#{__MODULE__} - failure: #{inspect(args)}")
+    def on_success(job, _result),       do: Logger.debug("#{__MODULE__} - success: #{inspect(job)}")
+    def on_failure(job, _err), do: Logger.debug("#{__MODULE__} - failure: #{inspect(job)}")
   end
 
 


### PR DESCRIPTION
In some cases, we might want to launch a background job that will fetch some data. Thus, the result of the job must be available.

Now, on_success/1 becomes on_success/2 which receives both job and the result. Also, on_failure/2 now receives the job instead of the job's arguments.

Instead of simply launch a new worker with Supervisor.start_child/2, Task.Supervisor.async_nolink/3 is then called. Once the job finishes, the parent is then called.

This PR introduces breaking changes as `Que.Worker.on_success/1` becomes `Que.Worker.on_success/2` and `Que.Worker.on_failure/2` now receives the job instead of the job's arguments. 